### PR TITLE
Created workflows for latest release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: build
+
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,29 @@
+name: pre-release
+
+on:
+  push:
+    branches: [ stage ]
+
+permissions:
+  contents: write
+
+jobs:
+  nightly:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: zip -r dist-nightly.zip dist
+      - uses: ncipollo/release-action@v1
+        with:
+          tag: nightly
+          name: Nightly
+          prerelease: true
+          allowUpdates: true
+          replacesArtifacts: true
+          artifacts: dist-nightly.zip

--- a/inventory-manager/.gitignore
+++ b/inventory-manager/.gitignore
@@ -17,7 +17,7 @@ package-lock.json
 .vscode/*
 !.vscode/extensions.json
 .idea
-.idea/
+.idea/*
 .DS_Store
 *.suo
 *.ntvs*


### PR DESCRIPTION
# added workflows

## Overall changes:
- Per-run artifact (`dist`) from CI.
- Rolling Nightly Release with zipped build asset.
- Added CI workflows to build Vite app on every push to `main`.
- Upload compiled `dist/` as Actions artifact.
- Added nightly prerelease pipeline: builds on `main`, attaches `dist-nightly.zip` to tag `nightly`.

ci: add GitHub Actions to build on main and publish dist as artifact
build: automate Vite build on main merges + nightly prerelease asset